### PR TITLE
feat: add basic support for 2d and columbus view

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ export default class CesiumDnD {
       this._entity = entity;
       this._initialEnableRotate = this.viewer.scene.screenSpaceCameraController.enableRotate;
       this._initialEnableTranslate = this.viewer.scene.screenSpaceCameraController.enableTranslate;
-      if (this.viewer.scene.mode === 3) {
+      if (this.viewer.scene.mode === Cesium.SceneMode.SCENE3D) {
         this.viewer.scene.screenSpaceCameraController.enableRotate = false;
       } else {
         this.viewer.scene.screenSpaceCameraController.enableTranslate = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ export default class CesiumDnD {
   private _handler?: ScreenSpaceEventHandler;
   private _initialEnableRotate = true;
   private _initialPosition?: PositionProperty;
+  private _initialEnableTranslate = true;
   private _initialScreenPosition?: Cartesian2;
   private _entity?: Entity;
   private _position: Cartesian3 | undefined;
@@ -112,6 +113,7 @@ export default class CesiumDnD {
     this._initialScreenPosition = undefined;
     this._timeout = undefined;
     this.viewer.scene.screenSpaceCameraController.enableRotate = this._initialEnableRotate;
+    this.viewer.scene.screenSpaceCameraController.enableTranslate = this._initialEnableTranslate;
     this.viewer.canvas.removeEventListener("blur", this.cancelDragging);
   };
 
@@ -145,7 +147,12 @@ export default class CesiumDnD {
       this._position = pos;
       this._entity = entity;
       this._initialEnableRotate = this.viewer.scene.screenSpaceCameraController.enableRotate;
-      this.viewer.scene.screenSpaceCameraController.enableRotate = false;
+      this._initialEnableTranslate = this.viewer.scene.screenSpaceCameraController.enableTranslate;
+      if (this.viewer.scene.mode === 3) {
+        this.viewer.scene.screenSpaceCameraController.enableRotate = false;
+      } else {
+        this.viewer.scene.screenSpaceCameraController.enableTranslate = false;
+      }
       this.viewer.canvas.addEventListener("blur", this.cancelDragging);
       entity.position = this._callbackProperty as any;
     };
@@ -190,6 +197,7 @@ export default class CesiumDnD {
     this._entity = undefined;
     this._timeout = undefined;
     this.viewer.scene.screenSpaceCameraController.enableRotate = this._initialEnableRotate;
+    this.viewer.scene.screenSpaceCameraController.enableTranslate = this._initialEnableTranslate;
     this.viewer.canvas.removeEventListener("blur", this.cancelDragging);
 
     const pos = this._convertCartesian2ToPosition(e.position);

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,8 +52,8 @@ export default class CesiumDnD {
   private _timeout?: number;
   private _handler?: ScreenSpaceEventHandler;
   private _initialEnableRotate = true;
-  private _initialPosition?: PositionProperty;
   private _initialEnableTranslate = true;
+  private _initialPosition?: PositionProperty;
   private _initialScreenPosition?: Cartesian2;
   private _entity?: Entity;
   private _position: Cartesian3 | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   ScreenSpaceEventHandler,
   ScreenSpaceEventType,
   Viewer,
+  SceneMode,
 } from "cesium";
 
 export type Context = {
@@ -148,7 +149,7 @@ export default class CesiumDnD {
       this._entity = entity;
       this._initialEnableRotate = this.viewer.scene.screenSpaceCameraController.enableRotate;
       this._initialEnableTranslate = this.viewer.scene.screenSpaceCameraController.enableTranslate;
-      if (this.viewer.scene.mode === Cesium.SceneMode.SCENE3D) {
+      if (this.viewer.scene.mode === SceneMode.SCENE3D) {
         this.viewer.scene.screenSpaceCameraController.enableRotate = false;
       } else {
         this.viewer.scene.screenSpaceCameraController.enableTranslate = false;


### PR DESCRIPTION
# Overview

This is required by reearth-web supporting 2d/2.5d mode. https://github.com/reearth/reearth/issues/300
When using 2d or columbus view the `ScreenSpaceCameraController` use `enableTranslate` to control the movement of the map instead of `enableRotate` which is used in 3d mode.

Also can you help release a new version on npm if this PR is approved?

## What I've done

- simply add enableTranslate control.

## What I haven't done

- Did not handle the height issue. in other words draging in 2d/2.5d mode will make the target pos exactly where the mouse  points to and lose the height value. I don't have a good solution for this issue now so this is just a basic update to enable draging in 2d/2.5d.
- For 3d we have `Ellipsoid` and `pickEllipsoid` to get the coordinates and can use a different ellipsolid to hold the height value, but for 2d/2.5d i haven't find something like pickPlane to use a new plane as pick target to hold the height. Any good idea?

## How I tested

Switch scene mode and drag the entities.

## Screenshot

![image](https://user-images.githubusercontent.com/21994748/170938653-9f93dbfa-70f8-47dc-a9ec-07ed911c713f.png)

![image](https://user-images.githubusercontent.com/21994748/170938517-a84b3dd0-aaa4-46d5-985a-37dd924e2dd5.png)



