### PR TITLE
feat: add basic height support for 2d and columbus

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ export default class CesiumDnD {
       this._entity = entity;
       this._initialEnableRotate = this.viewer.scene.screenSpaceCameraController.enableRotate;
       this._initialEnableTranslate = this.viewer.scene.screenSpaceCameraController.enableTranslate;
-      if (this.viewer.scene.mode === 3) {
+      if (this.viewer.scene.mode === Cesium.SceneMode.SCENE3D) {
         this.viewer.scene.screenSpaceCameraController.enableRotate = false;
       } else {
         this.viewer.scene.screenSpaceCameraController.enableTranslate = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ export default class CesiumDnD {
   private _handler?: ScreenSpaceEventHandler;
   private _initialEnableRotate = true;
   private _initialPosition?: PositionProperty;
+  private _initialEnableTranslate = true;
   private _initialScreenPosition?: Cartesian2;
   private _entity?: Entity;
   private _position: Cartesian3 | undefined;
@@ -112,6 +113,7 @@ export default class CesiumDnD {
     this._initialScreenPosition = undefined;
     this._timeout = undefined;
     this.viewer.scene.screenSpaceCameraController.enableRotate = this._initialEnableRotate;
+    this.viewer.scene.screenSpaceCameraController.enableTranslate = this._initialEnableTranslate;
     this.viewer.canvas.removeEventListener("blur", this.cancelDragging);
   };
 
@@ -145,7 +147,12 @@ export default class CesiumDnD {
       this._position = pos;
       this._entity = entity;
       this._initialEnableRotate = this.viewer.scene.screenSpaceCameraController.enableRotate;
-      this.viewer.scene.screenSpaceCameraController.enableRotate = false;
+      this._initialEnableTranslate = this.viewer.scene.screenSpaceCameraController.enableTranslate;
+      if (this.viewer.scene.mode === 3) {
+        this.viewer.scene.screenSpaceCameraController.enableRotate = false;
+      } else {
+        this.viewer.scene.screenSpaceCameraController.enableTranslate = false;
+      }
       this.viewer.canvas.addEventListener("blur", this.cancelDragging);
       entity.position = this._callbackProperty as any;
     };
@@ -190,6 +197,7 @@ export default class CesiumDnD {
     this._entity = undefined;
     this._timeout = undefined;
     this.viewer.scene.screenSpaceCameraController.enableRotate = this._initialEnableRotate;
+    this.viewer.scene.screenSpaceCameraController.enableTranslate = this._initialEnableTranslate;
     this.viewer.canvas.removeEventListener("blur", this.cancelDragging);
 
     const pos = this._convertCartesian2ToPosition(e.position);

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,8 +52,8 @@ export default class CesiumDnD {
   private _timeout?: number;
   private _handler?: ScreenSpaceEventHandler;
   private _initialEnableRotate = true;
-  private _initialPosition?: PositionProperty;
   private _initialEnableTranslate = true;
+  private _initialPosition?: PositionProperty;
   private _initialScreenPosition?: Cartesian2;
   private _entity?: Entity;
   private _position: Cartesian3 | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export default class CesiumDnD {
   private _initialEnableRotate = true;
   private _initialEnableTranslate = true;
   private _initialPosition?: PositionProperty;
+  private _initialHeight?: number | undefined;
   private _initialScreenPosition?: Cartesian2;
   private _entity?: Entity;
   private _position: Cartesian3 | undefined;
@@ -134,9 +135,16 @@ export default class CesiumDnD {
       if (c) {
         const height = this.viewer.scene.globe.ellipsoid.cartesianToCartographic(c).height;
         this._ellipsoid = CesiumDnD.enlargeEllipsoid(this.viewer.scene.globe.ellipsoid, height);
+
+        if (
+          this.viewer.scene.mode === SceneMode.SCENE2D ||
+          this.viewer.scene.mode === SceneMode.COLUMBUS_VIEW
+        ) {
+          this._initialHeight = height;
+        }
       }
 
-      const pos = this._convertCartesian2ToPosition(e.position);
+      const pos = this._resetHeight(this._convertCartesian2ToPosition(e.position));
       const ctx = this._context(pos, e.position);
       if (ctx && this.options?.onDrag?.(entity, pos, ctx) === false) {
         this._initialPosition = undefined;
@@ -170,7 +178,7 @@ export default class CesiumDnD {
     clearTimeout(this._timeout);
     if (!this._entity || this.viewer.isDestroyed() || !e?.endPosition) return;
 
-    const pos = this._convertCartesian2ToPosition(e.endPosition);
+    const pos = this._resetHeight(this._convertCartesian2ToPosition(e.endPosition));
     const ctx = this._context(pos, e.endPosition);
     if (!ctx) return;
 
@@ -201,11 +209,12 @@ export default class CesiumDnD {
     this.viewer.scene.screenSpaceCameraController.enableTranslate = this._initialEnableTranslate;
     this.viewer.canvas.removeEventListener("blur", this.cancelDragging);
 
-    const pos = this._convertCartesian2ToPosition(e.position);
+    const pos = this._resetHeight(this._convertCartesian2ToPosition(e.position));
     const ctx = this._context(pos, e.position);
 
     this._initialPosition = undefined;
     this._initialScreenPosition = undefined;
+    this._initialHeight = undefined;
     this._ellipsoid = undefined;
 
     if (ctx && this.options?.onDrop?.(entity, pos, ctx) !== false && pos) {
@@ -235,6 +244,19 @@ export default class CesiumDnD {
       position,
       this._ellipsoid ?? this.viewer.scene.globe.ellipsoid,
     );
+  }
+
+  private _resetHeight(position: Cartesian3 | undefined): Cartesian3 | undefined {
+    if (
+      position &&
+      (this.viewer.scene.mode === SceneMode.SCENE2D ||
+        this.viewer.scene.mode === SceneMode.COLUMBUS_VIEW) &&
+      this._initialHeight
+    ) {
+      const c = this.viewer.scene.globe.ellipsoid.cartesianToCartographic(position);
+      return Cartesian3.fromRadians(c.longitude, c.latitude, this._initialHeight);
+    }
+    return position;
   }
 
   private static enlargeEllipsoid(e: Ellipsoid, m: number): Ellipsoid {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   ScreenSpaceEventHandler,
   ScreenSpaceEventType,
   Viewer,
+  SceneMode,
 } from "cesium";
 
 export type Context = {
@@ -148,7 +149,7 @@ export default class CesiumDnD {
       this._entity = entity;
       this._initialEnableRotate = this.viewer.scene.screenSpaceCameraController.enableRotate;
       this._initialEnableTranslate = this.viewer.scene.screenSpaceCameraController.enableTranslate;
-      if (this.viewer.scene.mode === Cesium.SceneMode.SCENE3D) {
+      if (this.viewer.scene.mode === SceneMode.SCENE3D) {
         this.viewer.scene.screenSpaceCameraController.enableRotate = false;
       } else {
         this.viewer.scene.screenSpaceCameraController.enableTranslate = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,8 @@ export default class CesiumDnD {
           this.viewer.scene.mode === SceneMode.COLUMBUS_VIEW
         ) {
           this._initialHeight = height;
+        } else {
+          this._initialHeight = undefined;
         }
       }
 


### PR DESCRIPTION
# Overview

In 3d mode we already use a resized ellipsoid to hold the height value.
In 2d/2.5d mode draging entity will place it exactly where the mouse point to on the earth, which is logic but loss the height value.
In order to keep the same behavor between different scene modes we need to support height for 2d/2.5d.

Actually i didn't success in making ray caster to calcuate the coordinates on a vertual plane which is the better idea.

I simply stored the initial height and reset it during draging for 2d/2.5 mode. 

For 2d it's okey, but for 2.5d this solution still has diiferent behavor campare with the 3d mode as it actually place the entity to the mouse point position and with some height above it and this will lead to a jump. I think it's kind of acceptable for now, but if anyone has time looking into the issue later using ray solution will be great.

Btw, i think the behavor of holding height is good for drag as user won't see the jump of entity, but on the other hand it's also difficult to locate since the entity is not where the mouse point to unless using a straight up down view. so if possible maybe add a marker of the entities' shadow on earth will help locating. - or maybe we should keep it as simple as possible  and no excess entity should be added to the scene?

## What I've done

- store the initial height.
- set the height when draging in 2d/2.5d mode.

## What I haven't done

- Did not handle the coordinate calcuating with a virtual plane in 2.5d mode - which should be the better way.

## How I tested

Switch scene mode and drag the entities.
